### PR TITLE
Accordion Block - FAQ schema markup setting

### DIFF
--- a/Clean.Site/Views/Partials/blocklist/Components/accordionRow.cshtml
+++ b/Clean.Site/Views/Partials/blocklist/Components/accordionRow.cshtml
@@ -15,7 +15,7 @@
         <p>@row.Description</p>
     </header>
 
-    <div class="accordion" id="@accordionId">
+    <div class="accordion" id="@accordionId" @Html.Raw(settings?.ApplyFaqschema == true ? "itemscope itemtype=\"https://schema.org/FAQPage\"" : "")>
         @{
             var index = 0;
             foreach(var item in row.AccordionItems)
@@ -32,18 +32,38 @@
                 var headingId = accordionId + "-heading-" + index;
                 var collapseId = accordionId + "-collapse-" + index;
 
-                <div class="accordion-item">
-                    <h2 class="accordion-header" id="@headingId">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#@collapseId" aria-expanded="@show" aria-controls="@collapseId">
-                        @rowItem.Title
-                    </button>
-                    </h2>
-                    <div id="@collapseId" class="accordion-collapse collapse @(show ? "show" : null)" aria-labelledby="@headingId" data-bs-parent="#@accordionId">
-                    <div class="accordion-body">
-                        @rowItem.Content
+                @if (settings?.ApplyFaqschema == true)
+                {
+                    /// Example results: https://search.google.com/test/rich-results/result?id=DqdmFWs_XaONFgCO4JTzVQ
+                    /// 
+                    <div class="accordion-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+                        <h2 class="accordion-header" id="@headingId">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#@collapseId" aria-expanded="@show" aria-controls="@collapseId" itemprop="name">
+                                @rowItem.Title
+                            </button>
+                        </h2>
+                        <div id="@collapseId" class="accordion-collapse collapse @(show ? "show" : null)" aria-labelledby="@headingId" data-bs-parent="#@accordionId" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+                            <div class="accordion-body" itemprop="text">
+                                @rowItem.Content
+                            </div>
+                        </div>
                     </div>
+                }
+                else
+                {
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="@headingId">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#@collapseId" aria-expanded="@show" aria-controls="@collapseId">
+                                @rowItem.Title
+                            </button>
+                        </h2>
+                        <div id="@collapseId" class="accordion-collapse collapse @(show ? "show" : null)" aria-labelledby="@headingId" data-bs-parent="#@accordionId">
+                            <div class="accordion-body">
+                                @rowItem.Content
+                            </div>
+                        </div>
                     </div>
-                </div>
+                }
                 index++;
             }
         }

--- a/Clean.Site/uSync/v9/Content/about.config
+++ b/Clean.Site/uSync/v9/Content/about.config
@@ -309,7 +309,8 @@
     {
       "contentTypeKey": "6c624f81-186c-48a2-af6c-f6b48fa5f95f",
       "udi": "umb://element/0d0835716acd49d1b8c64f6cf6050206",
-      "hide": "0"
+      "hide": "0",
+      "applyFAQSchema": "1"
     },
     {
       "contentTypeKey": "6c624f81-186c-48a2-af6c-f6b48fa5f95f",

--- a/Clean.Site/uSync/v9/ContentTypes/accordionrowsettings.config
+++ b/Clean.Site/uSync/v9/ContentTypes/accordionrowsettings.config
@@ -22,6 +22,31 @@
     <AllowedTemplates />
   </Info>
   <Structure />
-  <GenericProperties />
-  <Tabs />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>ed406bb4-883e-421f-b915-1f54f80fb29a</Key>
+      <Name>Apply FAQ Schema</Name>
+      <Alias>applyFAQSchema</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Schema markup, also known as structured data, is the language search engines use to read and understand the content on your pages. Applying FAQ schema helps a search engine understand your accordion items and interprets them as FAQ's.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>3268ee08-5875-4d8f-8bf7-a9fce80fec1b</Key>
+      <Caption>Settings</Caption>
+      <Alias>settings</Alias>
+      <Type>Tab</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+  </Tabs>
 </ContentType>

--- a/Clean.Site/umbraco/models/AccordionRowSettings.generated.cs
+++ b/Clean.Site/umbraco/models/AccordionRowSettings.generated.cs
@@ -50,6 +50,13 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		// properties
 
 		///<summary>
+		/// Apply FAQ Schema: Schema markup, also known as structured data, is the language search engines use to read and understand the content on your pages. Applying FAQ schema helps a search engine understand your accordion items and interprets them as FAQ's.
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "10.1.0+3972538")]
+		[ImplementPropertyType("applyFAQSchema")]
+		public virtual bool ApplyFaqschema => this.Value<bool>(_publishedValueFallback, "applyFAQSchema");
+
+		///<summary>
 		/// Hide: Set this to true if you want to hide this item
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "10.1.0+3972538")]


### PR DESCRIPTION
Added the setting to the Accordion Row block to give the editor the ability to apply FAQ schema markup. Schema markup, also known as structured data, is the language search engines use to read and understand the content on your pages. Applying FAQ schema helps a search engine understand your accordion items and interprets them as FAQ's.